### PR TITLE
Fixed multiline block does not end with '|'

### DIFF
--- a/t/multiline.t
+++ b/t/multiline.t
@@ -15,7 +15,7 @@ my $output = $haml->render(<<'EOF');
     pretty long so I should   |
     probably make it          |
     multiline so it does not  |
-    look awful.
+    look awful.               |
   %p This is short.
 EOF
 is($output, <<'EOF');
@@ -32,7 +32,7 @@ $output = $haml->render(<<'EOF');
     pretty long so I should   |
     probably make it          |
     multiline so it does not  |
-    look awful.
+    look awful.               |
   %p This is short.
 EOF
 is($output, <<'EOF');

--- a/t/parse.t
+++ b/t/parse.t
@@ -290,7 +290,7 @@ is_deeply(
 $haml->parse(<<'EOF');
 multiline |
 comment   |
-parsing
+parsing   |
 normal
 EOF
 is_deeply(
@@ -298,7 +298,7 @@ is_deeply(
     [   {   type  => 'text',
             level => 0,
             text  => 'multiline comment parsing',
-            line  => "multiline |\ncomment   |\nparsing"
+            line  => "multiline |\ncomment   |\nparsing   |"
         },
         {   type  => 'text',
             level => 0,
@@ -315,7 +315,7 @@ is_deeply(
 $haml->parse(<<'EOF');
 %p multiline |
    comment   |
-   parsing
+   parsing   |
 normal
 EOF
 is_deeply(
@@ -324,7 +324,7 @@ is_deeply(
             level => 0,
             name  => 'p',
             text  => 'multiline comment parsing',
-            line  => "%p multiline |\ncomment   |\nparsing"
+            line  => "%p multiline |\ncomment   |\nparsing   |"
         },
         {   type  => 'text',
             level => 0,


### PR DESCRIPTION
According to current haml specification, even the last line in the multiline block should end with |.
http://haml.info/docs/yardoc/file.REFERENCE.html#multiline
So I fixed to follow this spec.
# TODO: to add test for mutiline token on last line

But I think this change will spoil existing haml files containing multiline block which does not end with '|'.
(What can we do? :( )
Is it better to control with switch or something else?
