### PR TITLE
Fixed printing 'ARRAY' on multiline token

### DIFF
--- a/t/multiline.t
+++ b/t/multiline.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Text::Haml;
 
-use Test::More tests => 2;
+use Test::More tests => 4;
 
 my $haml = Text::Haml->new;
 
@@ -42,4 +42,33 @@ is($output, <<'EOF');
   </hoo>
   <p>This is short.</p>
 </whoo>
+EOF
+
+$output = $haml->render(<<'EOF');
+%body
+  test
+  Wow.|
+  - my $bar = 17;
+  test2
+EOF
+is($output, <<'EOF');
+<body>
+  test
+  Wow.
+  test2
+</body>
+EOF
+
+$output = $haml->render(<<'EOF');
+%body
+  this is
+  a test for      |
+  multiline token |
+  on last line.   |
+EOF
+is($output, <<'EOF');
+<body>
+  this is
+  a test for multiline token on last line.
+</body>
 EOF


### PR DESCRIPTION
I'm sorry but I made big bug on multiline with [previous pull-req](https://github.com/vti/text-haml/pull/9).
Something like below will cause bad text "ARRAY(0xfoobar)" to be printed.

```
multiline |
%start_of_block_after_multiline
    ...
```
