### PR TITLE
Fix render file issues

### DIFF
--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -1037,6 +1037,11 @@ sub _fullpath {
     my $self = shift;
     my $path = shift;
 
+    if (File::Spec->file_name_is_absolute($path) and -r $path) {
+        $self->fullpath($path);
+        return;
+    }
+
     for my $p (@{$self->path}) {
         my $fullpath = File::Spec->catfile($p, $path);
         if (-r $fullpath) { # is readable ?

--- a/t/render_file.t
+++ b/t/render_file.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Text::Haml;
 
-use Test::More tests => 8;
+use Test::More tests => 9;
 
 use IO::File;
 use URI::Escape ();
@@ -35,6 +35,9 @@ my $output = $haml->render_file('render.haml', title => 'RENDER_FILE_TEST');
 $file->open(File::Spec->catfile('t', 'render1.html'), 'r') or die $!;
 my $expected1 = do { local $/; <$file> };
 $file->close;
+is($output, $expected1);
+
+$output = $haml->render_file( File::Spec->rel2abs(File::Spec->catfile('t', 'render1.haml')), title => 'RENDER_FILE_TEST');
 is($output, $expected1);
 
 my $uri_escaped = URI::Escape::uri_escape($tempdir);


### PR DESCRIPTION
While trying to use Text::Haml on our Mojolicious application we found a few problems with some recent changes to render_file:
- it fails if given a full path
- it fails if asked to render the same file more than once

Here's the patches we're using to fix it. I hope it is useful.

Let me know if you'd like anything done differently, I'd be happy to fix.
