### PR TITLE
Do not confuse double braces for attributes

### DIFF
--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -342,7 +342,7 @@ sub parse {
         if ($line =~ m/^(?:$tag_start
             |$class_start
             |$id_start
-            |$attributes_start
+            |$attributes_start[^$attributes_start]
             |$attributes_start2
             )/x
           )

--- a/t/html-attributes.t
+++ b/t/html-attributes.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 9;
 
 use Text::Haml;
 
@@ -43,6 +43,24 @@ is($output, <<'EOF');
 <html xmlns='http://www.w3.org/1999/xhtml' xml:lang='en' lang='en'>
   <div class='bar hello'></div>
 </html>
+EOF
+
+# Do not confuse double braces for attributes
+$output = $haml->render(<<'EOF');
+{{ foo }}
+EOF
+is($output, <<'EOF');
+{{ foo }}
+EOF
+
+$output = $haml->render(<<'EOF');
+%div{:class => 'foo'}
+  {{ bar }}
+EOF
+is($output, <<'EOF');
+<div class='foo'>
+  {{ bar }}
+</div>
 EOF
 #
 ## Attribute Methods


### PR DESCRIPTION
The following haml:

```
%div{:class => 'name'}
  {{ name }}
```

Should return:

```
<div class='name'>
  {{ name }}
</div>
```

However, it passes the regex for a tag and thus returns:

```
<div class='name'>
  <>{{ name }}</>
</div>
```

This prevents us from using any number of templating solutions which utilize `{{`. In my case, [mustache](https://github.com/janl/mustache.js).

Original issue cited [here](https://github.com/vti/text-haml/issues/15). Also submitted to [rt](https://rt.cpan.org/Public/Dist/Display.html?Name=Text-Haml)
