### PR TITLE
Add module dependency for render_file.t test

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,5 +43,8 @@ WriteMakefile(
         'File::Basename' => '0',
         'URI::Escape'    => '0',
     },
+    TEST_REQUIRES => {
+        'Data::Section::Simple' => '0',
+    },
     test => {TESTS => 't/*.t t/*/*.t t/*/*/*.t t/*/*/*/*.t'}
 );


### PR DESCRIPTION
render_file.t uses `Data::Section::Simple`, but there is no meta data in `Makefile.PL`.
So newly installation would be failed if `Data::Section::Simple` was not installed.
I added that in `TEST_REQUIRES`. :)
