### PR TITLE
parse `class` attr's text value before concatenate

### DIFF
--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -658,7 +658,7 @@ EOF
                         if ($name eq 'class') {
                             $el->{class} ||= [];
                             if ($value->{type} eq 'text') {
-                                push @{$el->{class}}, $text;
+                                push @{$el->{class}}, $self->_parse_text($text);
                             }
                             else {
                                 push @{$el->{class}}, qq/" . $text . "/;

--- a/t/class-and-id.t
+++ b/t/class-and-id.t
@@ -1,11 +1,15 @@
 #!/usr/bin/env perl
+package Foo;
+sub new { bless {}, shift }
+sub bar { 'baz' }
 
+package main;
 use strict;
 use warnings;
 
 use Text::Haml;
 
-use Test::More tests => 4;
+use Test::More tests => 5;
 
 my $haml = Text::Haml->new;
 
@@ -59,4 +63,11 @@ EOF
 is($output, <<'EOF');
 <foo class='bar'></foo>
 <bar class='bar baz'></bar>
+EOF
+
+$output = $haml->render(<<'EOF', foo => Foo->new());
+%span.badge{:class => "#{$foo->bar}"}
+EOF
+is($output, <<'EOF');
+<span class='badge baz'></span>
 EOF


### PR DESCRIPTION
```
%span.badge{:class => "#{$foo->bar}"}
## was
<span class='#{Foo=HASH(0x1b0c258)->foo} badge'></span>
## to be
<span class='badge baz'></span>
```
