### PR TITLE
Eliminate need for closing brace block (also leading `{` or `(` bugfix)

### DIFF
--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -333,8 +333,6 @@ sub parse {
         if ($line =~ m/^(?:$tag_start
             |$class_start
             |$id_start
-            |$attributes_start[^$attributes_start]
-            |$attributes_start2
             )/x
           )
         {

--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -657,9 +657,10 @@ EOF
 
                 if ($poped->{type} ne 'block') {
                     push @lines, qq|\$_H .= "$poped_offset$ending\n";|;
-                    _close_implicit_brace(\@lines);
                 }
 
+                _close_implicit_brace(\@lines);
+                
                 last STACKEDBLK if $poped->{level} == $el->{level};
             }
         }
@@ -795,6 +796,7 @@ EOF
             if ($el->{type} eq 'block') {
                 push @lines,  $el->{text};
                 push @$stack, $el;
+                _open_implicit_brace(\@lines);
 
                 if ($prev_el && $prev_el->{level} > $el->{level}) {
                     $in_block--;
@@ -883,7 +885,8 @@ EOF
         }
 
         push @lines, qq|\$_H .= "$offset$ending\n";| if $ending;
-        _close_implicit_brace(\@lines) unless $el->{type} eq 'block';
+
+        _close_implicit_brace(\@lines);
     }
 
     if ($lines[-1] && !$last_empty_line) {

--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -886,8 +886,13 @@ EOF
         _close_implicit_brace(\@lines) unless $el->{type} eq 'block';
     }
 
-    if ($lines[-1]) {
-        $lines[-1] =~ s/\n";$/";/ unless $last_empty_line;
+    if ($lines[-1] && !$last_empty_line) {
+        # usually (always?) there will be a closing '}' after the actual last .=
+        if ($lines[-2] && $lines[-1] eq '}') {
+            $lines[-2] =~ s/\n";$/";/;
+        } else {
+            $lines[-1] =~ s/\n";$/";/;
+        }
     }
 
     $code .= join("\n", @lines);

--- a/t/perl.t
+++ b/t/perl.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Text::Haml;
 
-use Test::More tests => 15;
+use Test::More tests => 16;
 
 my $haml = Text::Haml->new;
 my $output;
@@ -101,6 +101,29 @@ $output = $haml->render(<<'EOF');
    %li
      %foo
  - }
+%p End
+EOF
+is($output, <<'EOF');
+<ul>
+ <li>
+   <foo></foo>
+ </li>
+ <li>
+   <foo></foo>
+ </li>
+ <li>
+   <foo></foo>
+ </li>
+</ul>
+<p>End</p>
+EOF
+
+# same for loop, but utilising the new implicit bracing
+$output = $haml->render(<<'EOF');
+%ul
+ - foreach (1..3)
+   %li
+     %foo
 %p End
 EOF
 is($output, <<'EOF');

--- a/t/perl.t
+++ b/t/perl.t
@@ -142,6 +142,27 @@ is($output, <<'EOF');
 EOF
 
 $output = $haml->render(<<'EOF');
+ - foreach (1..3)
+   %p foo
+EOF
+is($output, <<'EOF');
+ <p>foo</p>
+ <p>foo</p>
+ <p>foo</p>
+EOF
+
+$output = $haml->render(<<'EOF');
+ - foreach (1..3)
+   %br/
+EOF
+is($output, <<'EOF');
+ <br />
+ <br />
+ <br />
+EOF
+
+
+$output = $haml->render(<<'EOF');
 %ul
   - foreach (1..1) {
     %li

--- a/t/plain.t
+++ b/t/plain.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Text::Haml;
 
-use Test::More tests => 6;
+use Test::More tests => 7;
 
 my $haml = Text::Haml->new;
 
@@ -25,6 +25,25 @@ is($output, <<'EOF');
   <whiz>
     Wow this is cool!
     <b>bold</b>
+  </whiz>
+</gee>
+EOF
+
+# bug with bare open bracket/brace
+$output = $haml->render(<<'EOF');
+%gee
+  %whiz
+    (
+  %whiz
+    {
+EOF
+is($output, <<'EOF');
+<gee>
+  <whiz>
+    (
+  </whiz>
+  <whiz>
+    {
   </whiz>
 </gee>
 EOF


### PR DESCRIPTION
Eliminate need for closing brace block by implicitly adding open/close braces at level changes. This allows more haml-ish for loops. Eg. from test:

```
%ul
 - foreach (1..3)
   %li
     %foo
%p End
```

Note that the existing tests where explicit braces are used still work since `{ { code; } }` is equivalent to `{ code; }`

All the tests pass, but it's possible I haven't thought of real haml that could result in `}{` being generated, which is the risk of causing a regression here.

Also fixes a bug where lines beginning with ( or { were getting wrapped in <></>.

These commits breaks no tests, and no additional haml-spec tests (the same 10 fail as for before these changes).