### PR TITLE
Block helpers

### DIFF
--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -333,8 +333,6 @@ sub parse {
         if ($line =~ m/^(?:$tag_start
             |$class_start
             |$id_start
-            |$attributes_start[^$attributes_start]
-            |$attributes_start2
             )/x
           )
         {

--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -657,9 +657,10 @@ EOF
 
                 if ($poped->{type} ne 'block') {
                     push @lines, qq|\$_H .= "$poped_offset$ending\n";|;
-                    _close_implicit_brace(\@lines);
                 }
 
+                _close_implicit_brace(\@lines);
+                
                 last STACKEDBLK if $poped->{level} == $el->{level};
             }
         }
@@ -795,6 +796,7 @@ EOF
             if ($el->{type} eq 'block') {
                 push @lines,  $el->{text};
                 push @$stack, $el;
+                _open_implicit_brace(\@lines);
 
                 if ($prev_el && $prev_el->{level} > $el->{level}) {
                     $in_block--;
@@ -883,7 +885,8 @@ EOF
         }
 
         push @lines, qq|\$_H .= "$offset$ending\n";| if $ending;
-        _close_implicit_brace(\@lines) unless $el->{type} eq 'block';
+
+        _close_implicit_brace(\@lines);
     }
 
     if ($lines[-1] && !$last_empty_line) {

--- a/lib/Text/Haml.pm
+++ b/lib/Text/Haml.pm
@@ -886,8 +886,13 @@ EOF
         _close_implicit_brace(\@lines) unless $el->{type} eq 'block';
     }
 
-    if ($lines[-1]) {
-        $lines[-1] =~ s/\n";$/";/ unless $last_empty_line;
+    if ($lines[-1] && !$last_empty_line) {
+        # usually (always?) there will be a closing '}' after the actual last .=
+        if ($lines[-2] && $lines[-1] eq '}') {
+            $lines[-2] =~ s/\n";$/";/;
+        } else {
+            $lines[-1] =~ s/\n";$/";/;
+        }
     }
 
     $code .= join("\n", @lines);

--- a/t/helpers.t
+++ b/t/helpers.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More tests => 3;
 
 use Text::Haml;
 
@@ -35,3 +35,73 @@ is($output, <<'EOF');
 baz
 hello
 EOF
+
+# helper that captures child block
+$haml->add_helper(block1 => sub {
+                      my $self = shift;
+                      my $block = shift;
+
+                      $block->();
+                      $block->();
+                      $block->();
+                  },
+                  prototype => '&',
+              );
+
+$output = $haml->render(<<'EOF');
+- block1
+  foo
+EOF
+is($output, <<'EOF');
+foo
+foo
+foo
+EOF
+
+# standard-ish helpers
+$haml->add_helper(precede => sub {
+                      my ($self, $text, $block) = @_;
+
+                      $self->namespace->outs($text);
+                      $block->();
+                  },
+                  prototype => '$&',
+                  arg_force_self => 1,
+              );
+
+$haml->add_helper(succeed => sub {
+                      my ($self, $text, $block) = @_;
+
+                      $block->();
+                      my $needs_newline = $self->namespace->out_chomp();
+                      $self->namespace->outs($text);
+                      $self->namespace->outs("\n") if $needs_newline;
+                      
+                  },
+                  prototype => '$&',
+                  arg_force_self => 1,
+              );
+
+$haml->add_helper(surround => sub {
+                      my ($self, $precede, $succeed, $block) = @_;
+
+                      $self->namespace->outs($precede);
+                      $block->();
+                      my $needs_newline = $self->namespace->out_chomp();
+                      $self->namespace->outs($succeed);
+                      $self->namespace->outs("\n") if $needs_newline;
+                  });
+
+$output = $haml->render(<<'EOF');
+- precede '*', sub
+  foo
+- succeed '*', sub
+  bar
+- surround '(', ')', sub
+  foobar
+EOF
+is($output, "*foo
+bar*
+(foobar)
+");
+

--- a/t/interpolation.t
+++ b/t/interpolation.t
@@ -94,10 +94,10 @@ EOF
 
 # Hashref interpolation
 $output = $haml->render(<<'EOF');
-- my $people = {
--    Alice => { role => 'sender'    },
--    Bob   => { role => 'recipient' },
-- };
+- my $people = {                       |
+     Alice => { role => 'sender'    }, |
+     Bob   => { role => 'recipient' }, |
+  };                                   |
 %p Alice has the role of #{$people->{Alice}->{role}}. Bob has the role of #{$people->{Bob}->{role}}.
 %p Bob has the role of #{$people->{Bob}->{role}}. Alice has the role of #{$people->{Alice}->{role}}.
 EOF
@@ -108,10 +108,10 @@ EOF
 
 # Hashref interpolation inside filters
 $output = $haml->render(<<'EOF');
-- my $vars = { 
--   settings => { type => 'text/javascript' },
--   request => { uri_base => '/path/to' },
-- };
+- my $vars = { |
+    settings => { type => 'text/javascript' }, |
+    request => { uri_base => '/path/to' }, |
+  }; |
 :javascript
   !window.jQuery && document.write('<script type="#{$vars->{settings}->{type}}" src="#{$vars->{request}->{uri_base}}/javascripts/jquery.js"><\/script>')
 EOF

--- a/t/interpolation.t
+++ b/t/interpolation.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
+use Test::More tests => 11;
 
 use Text::Haml;
 
@@ -105,6 +105,28 @@ is($output, <<'EOF');
 <p>Alice has the role of sender. Bob has the role of recipient.</p>
 <p>Bob has the role of recipient. Alice has the role of sender.</p>
 EOF
+
+# Seqeuntial multi-line perl blocks
+$output = $haml->render(<<'EOF');
+- my $people = {                       |
+     Alice => { role => 'sender'    }, |
+     Bob   => { role => 'recipient' }, |
+  };                                   |
+- my $foo = "Hello " . |
+  "World";             |
+- die unless 1;
+- die                             |
+    unless $foo eq 'Hello World'; |
+%p Alice has the role of #{$people->{Alice}->{role}}. Bob has the role of #{$people->{Bob}->{role}}.
+- die                                          |
+    unless $people->{Alice}{role} eq 'sender'; |
+%p Bob has the role of #{$people->{Bob}->{role}}. Alice has the role of #{$people->{Alice}->{role}}.
+EOF
+is($output, <<'EOF');
+<p>Alice has the role of sender. Bob has the role of recipient.</p>
+<p>Bob has the role of recipient. Alice has the role of sender.</p>
+EOF
+
 
 # Hashref interpolation inside filters
 $output = $haml->render(<<'EOF');

--- a/t/perl.t
+++ b/t/perl.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Text::Haml;
 
-use Test::More tests => 16;
+use Test::More tests => 18;
 
 my $haml = Text::Haml->new;
 my $output;
@@ -224,8 +224,6 @@ is($output, <<'EOF');
 0
 
 EOF
-
-#warn $haml->code;
 
 # Inserting variables
 $output = $haml->render(<<'EOF', foo => 1, bar => 2);

--- a/t/perl.t
+++ b/t/perl.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Text::Haml;
 
-use Test::More tests => 15;
+use Test::More tests => 16;
 
 my $haml = Text::Haml->new;
 my $output;
@@ -101,6 +101,29 @@ $output = $haml->render(<<'EOF');
    %li
      %foo
  - }
+%p End
+EOF
+is($output, <<'EOF');
+<ul>
+ <li>
+   <foo></foo>
+ </li>
+ <li>
+   <foo></foo>
+ </li>
+ <li>
+   <foo></foo>
+ </li>
+</ul>
+<p>End</p>
+EOF
+
+# same for loop, but utilising the new implicit bracing
+$output = $haml->render(<<'EOF');
+%ul
+ - foreach (1..3)
+   %li
+     %foo
 %p End
 EOF
 is($output, <<'EOF');

--- a/t/perl.t
+++ b/t/perl.t
@@ -142,6 +142,27 @@ is($output, <<'EOF');
 EOF
 
 $output = $haml->render(<<'EOF');
+ - foreach (1..3)
+   %p foo
+EOF
+is($output, <<'EOF');
+ <p>foo</p>
+ <p>foo</p>
+ <p>foo</p>
+EOF
+
+$output = $haml->render(<<'EOF');
+ - foreach (1..3)
+   %br/
+EOF
+is($output, <<'EOF');
+ <br />
+ <br />
+ <br />
+EOF
+
+
+$output = $haml->render(<<'EOF');
 %ul
   - foreach (1..1) {
     %li

--- a/t/plain.t
+++ b/t/plain.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Text::Haml;
 
-use Test::More tests => 6;
+use Test::More tests => 7;
 
 my $haml = Text::Haml->new;
 
@@ -25,6 +25,25 @@ is($output, <<'EOF');
   <whiz>
     Wow this is cool!
     <b>bold</b>
+  </whiz>
+</gee>
+EOF
+
+# bug with bare open bracket/brace
+$output = $haml->render(<<'EOF');
+%gee
+  %whiz
+    (
+  %whiz
+    {
+EOF
+is($output, <<'EOF');
+<gee>
+  <whiz>
+    (
+  </whiz>
+  <whiz>
+    {
   </whiz>
 </gee>
 EOF


### PR DESCRIPTION
Hi again @vti,

This is more a discussion pull request for now, building on PR #38 (which I think is ready now).

I wanted a way to implement the standard helpers `surround`, `precede` and `succeed` as well as a way for end users to implement similar helpers. Without drastic changes I've implemented something that is so similar that it's easy to understand, if not identical (after all, ruby code like `do` isn't going to work anyway).

I'd push the standard helpers into the main code, but for now it's all in `t/helpers.t` which also shows how end users could use it. Ideally the helpers would be used with `=` lines rather than `-` which would mean `return` instead of `outs` et al. (I'd consider the `outs[_raw]` api as temporary and would advertise it in the pod as such, but the other approach will require a bigger refactor than I'm willing to put time into right now, due to the `do {}` block etc.

The only unavoidable regression this introduces due to the vagaries of Perl syntax is that each `-` line must be a complete Perl statement (since they are preceded by `;`). This means splitting a Perl statement across lines like the `t/interpolation.t` test used to no longer works. Instead I've implemented support for `|` style Haml multi-line code blocks, and updated two tests in `t/interpolation.t` to use them.

Let me know what you think.

Cheers,

Mark.

PS: Note that this code still doesn't work in all cases, the way the `{}` blocks are extended is too aggressive - it needs to be done to properly match indentation levels.
